### PR TITLE
Fixing wrong bundle name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ public function registerBundles()
 {
     $bundles = array(
         // ...
-        new Exercise\Bundle\GoogleTranslateBundle\GoogleTranslateBundle(),
+        new Exercise\GoogleTranslateBundle\ExerciseGoogleTranslateBundle(),
     );
 }
 ```


### PR DESCRIPTION
Looks like this was changed at some point but the readme wasnt.
