### PR TITLE
Add bundles and domains options

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,28 @@ public function indexAction() {
     return new Response($translatedString);
 }
 ```
-or you can use console command to translate messages
+Or you can use console command to translate messages
 
 ```bash
-app/console gtranslate:translate en fr AcmeDemoBundle
+app/console gtranslate:translate [--override] [-d|--domains[="..."]] localeFrom localeTo [bundles]
+```
+
+Command arguments:
+* `localeFrom`: Locale from
+* `localeTo`: Locale to
+* `bundles`: Import translation for this specific bundles (comma separted) [optional]
+
+Command options:
+* `--override`: Override existing translation [optional]
+* `--domains` (or -d): Only imports files for given domains (comma separated) [optional]
+
+
+Example:
+
+```bash
+$ app/console gtranslate:translate en fr AcmeFooBundle
+$ app/console gtranslate:translate en it --domains=messages,foo,bar
+$ app/console gtranslate:translate en es AcmeFooBundle,AcmeBarBundle --domains=messages,foo,bar
 ```
 
 Bug tracking


### PR DESCRIPTION
Add two new features:

1 / You can select in the CLI one or more bundles... and all the project bundles and app if you don't give the argument.

2 / You can select in the CLI one or more translation domains... and all the translation domains if you don't give the `domains` option.

CLI
```bash
app/console gtranslate:translate [--override] [-d|--domains[="..."]] localeFrom localeTo [bundles]
```

E.g.
```bash
$ app/console gtranslate:translate en fr AcmeFooBundle
$ app/console gtranslate:translate en it --domains=messages,foo,bar
$ app/console gtranslate:translate en es AcmeFooBundle,AcmeBarBundle --domains=messages,foo,bar
```

This two new features are add to the README doc.

Happy reviewing :smile: